### PR TITLE
Added capabilities param to aws cloudformation deploy to make the deployment work properly.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,8 @@ deploy: build
 		--no-fail-on-empty-changeset \
 		--template-file template_deploy.yaml \
 		--stack-name $(STACK_NAME) \
-		--parameter-overrides "ResourceBucket=$(STACK_BUCKET)" "YourEmail=$(YOUR_EMAIL)"
+		--parameter-overrides "ResourceBucket=$(STACK_BUCKET)" "YourEmail=$(YOUR_EMAIL)" \
+        --capabilities CAPABILITY_IAM
 
 .PHONY: teardown
 teardown:


### PR DESCRIPTION
The docs indicate that the capabilities param is optional, but that's misleading.
When you actually run the command, it really does want this parameter.